### PR TITLE
{ added in javascript call

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ In the template:
    <!-- the graph container -->
    <div id="container" style="height: 400px; min-width: 310px; max-width: 1200px; margin: 0 auto"></div>
    <!-- the javascript call -->
-    $(function () 
-            $.getJSON("{% url 'bar' %}", function(data) 
-                $('#container').highcharts(data);
-            });
-    });
+   $(function () {
+       $.getJSON("{% url 'bar' %}", function(data) {
+           $('#container').highcharts(data);
+       });
+   })
 ```
 
 An advanced example with parameters passed via url and data retrived from db (using orm or raw query)


### PR DESCRIPTION
It took me a while to figure out why my highcharts didn't work any more after updating to the latest version. To isolate the problem, I created a minimal example using the documentation from README.md. Then I found out that 2 missing { were the issue.